### PR TITLE
Resolves an issue joining multicast when no IPv6 address present

### DIFF
--- a/Sources/OTPKit/Components/ComponentSocket.swift
+++ b/Sources/OTPKit/Components/ComponentSocket.swift
@@ -216,8 +216,12 @@ class ComponentSocket: NSObject, GCDAsyncUdpSocketDelegate {
         do {
             switch socketType {
             case .unicast:
-                // try socket?.sendIPv4Multicast(onInterface: interface)
-                try socket?.sendIPv6Multicast(onInterface: interface)
+//                if multicastGroups.contains(where: { IPv4Address($0) != nil }) {
+//                    try socket?.sendIPv4Multicast(onInterface: interface)
+//                }
+                if multicastGroups.contains(where: { IPv6Address($0) != nil }) {
+                    try socket?.sendIPv6Multicast(onInterface: interface)
+                }
             case .multicastv4, .multicastv6:
                 break
             }


### PR DESCRIPTION
If no IPv6 address was present on an interface a call would be made which would throw, and thus the connection would not be established correctly. Fixed by only attempting to chose the interface when one or more addresses are IPv6