### PR TITLE
Close socket if multicast join fails

### DIFF
--- a/Sources/OTPKit/Components/ComponentSocket.swift
+++ b/Sources/OTPKit/Components/ComponentSocket.swift
@@ -243,7 +243,12 @@ class ComponentSocket: NSObject, GCDAsyncUdpSocketDelegate {
             break
         case .multicastv4, .multicastv6:
             for group in multicastGroups {
-                try join(multicastGroup: group)
+                do {
+                    try join(multicastGroup: group)
+                } catch {
+                    socket?.close()
+                    throw error
+                }
             }
         }
 


### PR DESCRIPTION
If multicast join fails the `OTPConsumer` multicast sockets (IPv4/6) are left in a listening state, even though the `OTPConsumer` is flagged as not listening. This means a subsequent attempt to bind fails.

It is possible at intial launch (shortly after boot) IGMP joins may not be transmitted. In these situations it is best to close the socket, so implementors can reliably tell the state of the receiver and attempt to start again.